### PR TITLE
Local move functionality to get the log to "exit" the game board

### DIFF
--- a/.xatarc
+++ b/.xatarc
@@ -2,6 +2,6 @@
   "databaseURL": "https://Jason-K-Frank-s-workspace-ul7brh.us-east-1.xata.sh/db/xata-worker-game",
   "codegen": {
     "output": "xata.ts",
-    "workersBuildId": "cg2m0vh42goju7got620"
+    "workersBuildId": "cg4eog5mc0gv00nm5m5g"
   }
 }

--- a/app/(no-page-transitions)/raw/page.tsx
+++ b/app/(no-page-transitions)/raw/page.tsx
@@ -6,9 +6,5 @@ export const metadata = {
 };
 
 export default function Raw() {
-  return (
-    <div className="w-full">
-      <XataGame />
-    </div>
-  );
+  return <XataGame />;
 }

--- a/app/(with-page-transitions)/layout.tsx
+++ b/app/(with-page-transitions)/layout.tsx
@@ -1,12 +1,15 @@
 import AppBar from "components/app-bar/app-bar";
 
-export default function RootLayout({
+export default function RegularPagesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <div
+      className="grid h-full grid-rows-[auto_1fr_auto] justify-items-center
+                     selection:bg-[#08eeb2] selection:text-black"
+    >
       <AppBar />
 
       <main
@@ -35,6 +38,6 @@ export default function RootLayout({
           with Next.js, Tailwind.css, Framer Motion and Vercel
         </p>
       </footer>
-    </>
+    </div>
   );
 }

--- a/app/(with-page-transitions)/page.tsx
+++ b/app/(with-page-transitions)/page.tsx
@@ -17,7 +17,10 @@ export default function Home() {
           function.  Hopefully the difference is pretty small!            
           `}
       </p>
-      <XataGame className="h-[392px] sm:h-[520px]" />
+      {/* NOTE: Don't apply the sizing classes directly to the XataGame component since they won't override the component's size classes in the production build */}
+      <div className="h-[392px] sm:h-[520px]">
+        <XataGame />
+      </div>
     </div>
   );
 }

--- a/app/(with-page-transitions)/page.tsx
+++ b/app/(with-page-transitions)/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
           function.  Hopefully the difference is pretty small!            
           `}
       </p>
-      <XataGame />
+      <XataGame className="h-[392px] sm:h-[520px]" />
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,13 +38,10 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn(poppins.className, "h-full")}>
       <head />
-      {/* This particular grid-rows (grid-template-rows in CSS) settings allows the middle row to take up all remainging space */}
-      <body
-        className="grid h-full grid-rows-[auto_1fr_auto] justify-items-center 
-                 selection:bg-[#08eeb2] selection:text-black"
-      >
+
+      <body className="h-full">
         {/* Notes:
-                (1) The childre may also be wrapped by nested layout file(s). 
+                (1) The children may also be wrapped by nested layout file(s). 
                 (2) The children are also wrapped by my `template.tsx` (if present at some level).  See: https://beta.nextjs.org/docs/routing/pages-and-layouts#templates 
                     That file can be useful for applying page transitions, etc.
           */}

--- a/components/xata-game/xata-game.module.css
+++ b/components/xata-game/xata-game.module.css
@@ -1,5 +1,6 @@
 /* I'm using a CSS file in this case because grid-template-areas don't seem to be easy with Tailwind utility classes currently */
 .root {
+  height: 100%;
   display: grid;
   grid-template-columns: auto 1fr auto;
   place-items: stretch;
@@ -7,6 +8,8 @@
     "topLeft     topCenter     topRight"
     "middleLeft  middleCenter  middleRight"
     "bottomLeft  bottomCenter  bottomRight";
+
+  grid-template-rows: auto 1fr auto;
 }
 .root > * {
   margin: 4px;
@@ -32,4 +35,6 @@
 
 .gameBoard {
   grid-area: middleCenter;
+  height: auto;
+  overflow: hidden;
 }

--- a/components/xata-game/xata-game.tsx
+++ b/components/xata-game/xata-game.tsx
@@ -10,6 +10,7 @@ import ExpandMoreGlyph from "components/icon-glyphs/expand_more-glyph";
 import IconButton from "components/icon/icon-button";
 import CompanyLogo from "../xata-logo";
 import styles from "./xata-game.module.css";
+import debounce from "lib/debounce";
 
 enum MoveDirection {
   Up = "Up",
@@ -31,45 +32,98 @@ const moveViaXataWorker = xataWorker(
 
 export default function XataGame({ className }: { className?: string }) {
   const [logoTranslateY, setLogoTranslateY] = useState<number>(0);
-  const gameBoardRef = useRef<HTMLElement>();
+  const [logoTranslateX, setLogoTranslateX] = useState<number>(0);
+  // Need to pass-in null since this ref is to store a reference to an HTML element (as opposed to an arbitrary variable). Initializing it with null makes the ref's 'current' property readonly and satisfies the TypeScrip compiler.  See: https://stackoverflow.com/a/61680609/718325
+  const gameBoardRef = useRef<HTMLElement>(null);
   const gameBoardResizeOberserverRef = useRef<ResizeObserver>();
-
-  function handleGameBoardResize(entries: any) {
-    for (const entry of entries) {
-      console.log(entry);
-    }
-  }
+  const gameBoardWidthRef = useRef<number>();
+  const gameBoardHeightRef = useRef<number>();
+  // The number of "steps" (generally clicks), in any direction, for the logo to go to exit the board.
+  const stepsToExit = 10;
+  const currentYStepRef = useRef<number>(0); // The logo will "exit" the board once (abs(currentYStepRef.current) > stepsToExit)
+  const currentXStepRef = useRef<number>(0);
+  const [hasExited, setHasExited] = useState<boolean>(false);
 
   useEffect(() => {
-    gameBoardResizeOberserverRef.current = new ResizeObserver(
-      handleGameBoardResize
-    );
-    gameBoardResizeOberserverRef.current.observe(
-      gameBoardRef.current as HTMLElement
-    );
+    function handleGameBoardResize(
+      resizeObserverEntries: ResizeObserverEntry[]
+    ) {
+      // We only have one entry in our case, so I'm just extracting that one
+      const gameBoardResizeEntry = resizeObserverEntries[0];
+      const { contentRect } = gameBoardResizeEntry;
+      gameBoardWidthRef.current = contentRect.width;
+      gameBoardHeightRef.current = contentRect.height;
+      // Need to update the logo's position here because the previous translate amount was based on the previous board size (this keeps is positioned at the correct percentage toward the exit)
+      updatePosition();
+    }
+    (function setUpBoardResizeObserver() {
+      gameBoardResizeOberserverRef.current = new ResizeObserver(
+        debounce(handleGameBoardResize, 200)
+      );
+      gameBoardResizeOberserverRef.current.observe(
+        gameBoardRef.current as HTMLElement
+      );
+    })();
 
     const board = gameBoardRef.current;
-    console.log({
-      width: board?.offsetWidth,
-      height: board?.offsetHeight,
-    });
+    gameBoardWidthRef.current = board?.offsetWidth;
+    gameBoardHeightRef.current = board?.offsetHeight;
   }, []);
+
+  useEffect(() => {
+    console.log("New hasExisted: " + hasExited);
+  }, [hasExited]);
 
   const iconButtonHoverElementClassNameProp = {
     hoverElementClassName:
       "rounded-lg top-0 bottom-0 left-0 right-0 scale-75 group-hover:opacity-10",
   };
 
+  function updatePosition() {
+    if (!gameBoardHeightRef.current || !gameBoardWidthRef.current) {
+      return;
+    }
+    const yPercentTowardExit = currentYStepRef.current / stepsToExit;
+    const newTranslateY = yPercentTowardExit * (gameBoardHeightRef.current / 2);
+    setLogoTranslateY(newTranslateY);
+
+    const xPercentTowardExit = currentXStepRef.current / stepsToExit;
+    const newTranslateX = xPercentTowardExit * (gameBoardWidthRef.current / 2);
+    setLogoTranslateX(newTranslateX);
+  }
+
   async function handleArrowClick(direction: MoveDirection) {
-    switch (direction) {
-      case MoveDirection.Up:
-        setLogoTranslateY((prev) => prev - 10);
-        break;
+    if (!gameBoardHeightRef.current || !gameBoardWidthRef.current) {
+      return;
     }
 
-    const xataWorkerResult = await moveViaXataWorker(direction);
-    console.log(xataWorkerResult);
+    switch (direction) {
+      case MoveDirection.Up:
+        currentYStepRef.current--; // decrement because upward is negative with CSS translate (so this keeps that mindset consistent)
+        break;
+      case MoveDirection.Down:
+        currentYStepRef.current++;
+        break;
+      case MoveDirection.Left:
+        currentXStepRef.current--;
+        break;
+      case MoveDirection.Right:
+        currentXStepRef.current++;
+    }
+    updatePosition();
+
+    if (
+      Math.abs(currentYStepRef.current) > stepsToExit ||
+      Math.abs(currentXStepRef.current) > stepsToExit
+    ) {
+      setHasExited(true);
+    }
+
+    // TODO:  Xata worker aspect
+    // const xataWorkerResult = await moveViaXataWorker(direction);
+    // console.log(xataWorkerResult);
   }
+  const gameBoardColorClassNames = hasExited ? "bg-green-600" : "bg-gray-800";
 
   return (
     <section className={cn(styles.root, className)}>
@@ -93,7 +147,8 @@ export default function XataGame({ className }: { className?: string }) {
         ref={gameBoardRef}
         className={cn(
           styles.gameBoard,
-          "relative rounded-lg bg-gray-800 text-white"
+          "relative rounded-lg  text-white",
+          gameBoardColorClassNames
         )}
       >
         <span
@@ -102,8 +157,10 @@ export default function XataGame({ className }: { className?: string }) {
                         sm:top-[calc(50%-24px)] sm:left-[calc(50%-24px)]"
         >
           <CompanyLogo
-            style={{ transform: `translateY(${logoTranslateY}px)` }}
-            className="h-[32px] sm:h-[40px]"
+            style={{
+              transform: `translateY(${logoTranslateY}px) translateX(${logoTranslateX}px)`,
+            }}
+            className="h-[32px] transition duration-75 sm:h-[40px]"
             wingsFill="#bbbbbb"
           />
         </span>

--- a/components/xata-game/xata-game.tsx
+++ b/components/xata-game/xata-game.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { useEffect, useRef, useState } from "react";
 import { xataWorker } from "xata";
 import cn from "classnames";
 import ChevronLeftGlyph from "components/icon-glyphs/chevron_left-glyph";
@@ -28,21 +29,50 @@ const moveViaXataWorker = xataWorker(
   }
 );
 
-export default function XataGame() {
+export default function XataGame({ className }: { className?: string }) {
+  const [logoTranslateY, setLogoTranslateY] = useState<number>(0);
+  const gameBoardRef = useRef<HTMLElement>();
+  const gameBoardResizeOberserverRef = useRef<ResizeObserver>();
+
+  function handleGameBoardResize(entries: any) {
+    for (const entry of entries) {
+      console.log(entry);
+    }
+  }
+
+  useEffect(() => {
+    gameBoardResizeOberserverRef.current = new ResizeObserver(
+      handleGameBoardResize
+    );
+    gameBoardResizeOberserverRef.current.observe(
+      gameBoardRef.current as HTMLElement
+    );
+
+    const board = gameBoardRef.current;
+    console.log({
+      width: board?.offsetWidth,
+      height: board?.offsetHeight,
+    });
+  }, []);
+
   const iconButtonHoverElementClassNameProp = {
     hoverElementClassName:
       "rounded-lg top-0 bottom-0 left-0 right-0 scale-75 group-hover:opacity-10",
   };
 
   async function handleArrowClick(direction: MoveDirection) {
-    // TODO: affect a "local change"
+    switch (direction) {
+      case MoveDirection.Up:
+        setLogoTranslateY((prev) => prev - 10);
+        break;
+    }
 
     const xataWorkerResult = await moveViaXataWorker(direction);
     console.log(xataWorkerResult);
   }
 
   return (
-    <section className={styles.root}>
+    <section className={cn(styles.root, className)}>
       <IconButton
         className={styles.upArrow}
         onClick={() => handleArrowClick(MoveDirection.Up)}
@@ -60,13 +90,22 @@ export default function XataGame() {
       </IconButton>
 
       <span
+        ref={gameBoardRef}
         className={cn(
           styles.gameBoard,
-          "relative h-72 justify-self-stretch rounded-lg bg-gray-800 text-white"
+          "relative rounded-lg bg-gray-800 text-white"
         )}
       >
-        <span className="absolute top-[calc(50%-24px)] left-[calc(50%-24px)]">
-          <CompanyLogo className="h-[40px]" wingsFill="#bbbbbb" />
+        <span
+          className="absolute 
+                        top-[calc(50%-16px)] left-[calc(50%-16px)]  
+                        sm:top-[calc(50%-24px)] sm:left-[calc(50%-24px)]"
+        >
+          <CompanyLogo
+            style={{ transform: `translateY(${logoTranslateY}px)` }}
+            className="h-[32px] sm:h-[40px]"
+            wingsFill="#bbbbbb"
+          />
         </span>
       </span>
 
@@ -77,7 +116,6 @@ export default function XataGame() {
       >
         <ChevronRightGlyph />
       </IconButton>
-      {/* </div> */}
 
       <IconButton
         className={styles.downArrow}

--- a/components/xata-game/xata-game.tsx
+++ b/components/xata-game/xata-game.tsx
@@ -76,7 +76,7 @@ export default function XataGame({ className }: { className?: string }) {
 
   const iconButtonHoverElementClassNameProp = {
     hoverElementClassName:
-      "rounded-lg top-0 bottom-0 left-0 right-0 scale-75 group-hover:opacity-10",
+      "!rounded-lg !top-0 !bottom-0 !left-0 !right-0 scale-75 !group-hover:opacity-10",
   };
 
   function updatePosition() {

--- a/components/xata-game/xata-game.tsx
+++ b/components/xata-game/xata-game.tsx
@@ -120,8 +120,8 @@ export default function XataGame({ className }: { className?: string }) {
     }
 
     // TODO:  Xata worker aspect
-    // const xataWorkerResult = await moveViaXataWorker(direction);
-    // console.log(xataWorkerResult);
+    //const xataWorkerResult = await moveViaXataWorker(direction);
+    //console.log(xataWorkerResult);
   }
   const gameBoardColorClassNames = hasExited ? "bg-green-600" : "bg-gray-800";
 

--- a/components/xata-logo.tsx
+++ b/components/xata-logo.tsx
@@ -1,7 +1,9 @@
 export default function XataLogo({
+  style,
   className,
   wingsFill,
 }: {
+  style?: object;
   className?: string;
   wingsFill?: string;
 }) {
@@ -11,6 +13,7 @@ export default function XataLogo({
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 32 32"
       className={className}
+      style={style}
     >
       <g clipPath="url(#a)">
         <path

--- a/lib/debounce.ts
+++ b/lib/debounce.ts
@@ -1,0 +1,24 @@
+export default function debounce(
+  callback: Function,
+  delay: number,
+  immediate = false
+) {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Note: We can't use an arrow function for the returned function b/c
+  //       arrow functions don't get their own 'this' context and in this case we need that so
+  //       that we can in-turn set the 'this' context for the underlying callback with ".apply()"
+  return function (this: unknown, ...args: any) {
+    timeoutId && clearTimeout(timeoutId);
+
+    const shouldCallImmediately = timeoutId === null && immediate;
+    if (shouldCallImmediately) {
+      callback.apply(this, args);
+    }
+    timeoutId = setTimeout(() => {
+      if (!immediate) {
+        callback.apply(this, args);
+      }
+      timeoutId = null;
+    }, delay);
+  };
+}

--- a/xata.ts
+++ b/xata.ts
@@ -37,5 +37,5 @@ export const getXataClient = () => {
 
 export const xataWorker = buildWorkerRunner<XataClient>({
   workspace: "Jason-K-Frank-s-workspace-ul7brh",
-  worker: "cg2m0vh42goju7got620",
+  worker: "cg4eog5mc0gv00nm5m5g",
 });


### PR DESCRIPTION
Also handles window/element resizing such that the logo stays in the same percentage position.

Right now I have the Xata Worker function turned off since that network call bombs right now.